### PR TITLE
use arrow functions instead of function expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5"
+  - "6"
 notifications:
   webhooks:
     urls:

--- a/lib/mocks/mock.js
+++ b/lib/mocks/mock.js
@@ -32,25 +32,25 @@ class Mock {
   }
 
   restoreMocks() {
-    _.forEach(this._mocks_, function (mockedFunctions, mockName) {
-      _.forEach(mockedFunctions, function (mockedFunction, funcName) {
+    _.forEach(this._mocks_, (mockedFunctions, mockName) => {
+      _.forEach(mockedFunctions, (mockedFunction, funcName) => {
 
         if (this._mocks_[mockName][funcName].objectToMock[funcName].restore) {
           this._mocks_[mockName][funcName].objectToMock[funcName].restore();
         }
 
-      }.bind(this));
-    }.bind(this));
+      });
+    });
   }
 
   restoreMockCallCounts() {
-    _.forEach(this._mocks_, function (mockedFunctions, mockName) {
-      _.forEach(mockedFunctions, function (mockedFunction, funcName) {
+    _.forEach(this._mocks_, (mockedFunctions, mockName) => {
+      _.forEach(mockedFunctions, (mockedFunction, funcName) => {
 
         this._mocks_[mockName][funcName].callCount = 0;
 
-      }.bind(this));
-    }.bind(this));
+      });
+    });
   }
 
   promiseResult(mockName, funcName, mockedData) {
@@ -150,11 +150,11 @@ class Mock {
       objectToMock[funcName].restore();
     }
 
-    sinon.stub(objectToMock, funcName, function () {
+    sinon.stub(objectToMock, funcName, (...args) => {
       let mockedResult,
         mock = this._mocks_[mockName][funcName];
 
-      mock.actual.push(arguments);
+      mock.actual.push(args);
 
       if (mock.responseEnd) {
         this.resolveForResponseEnd();
@@ -168,11 +168,11 @@ class Mock {
         mock.callCount = mock.callCount + 1;
 
         // This execution will call one of these three functions synchronousResult, callbackResult, or promiseResult.
-        mockedResult = this[mockedData.dataReturnType](mockName, funcName, mockedData, arguments);
+        mockedResult = this[mockedData.dataReturnType](mockName, funcName, mockedData, args);
       }
 
       return mockedResult;
-    }.bind(this));
+    });
   }
 
   setCallbackForResponseEnd(resolveForResponseEnd) {
@@ -190,9 +190,9 @@ class Mock {
     delete this._mocks_[constants.ResponseMockName];
 
     // LOOPING THROUGH MOCKS
-    _.forEach(this._mocks_, function (mockedFunctions, mockName) {
+    _.forEach(this._mocks_, (mockedFunctions, mockName) => {
       this.testMock(mockedFunctions, mockName);
-    }.bind(this));
+    });
 
     // Add back response mocks so perf tests can use them.
     this._mocks_[constants.ResponseMockName] = this._responseMocks_;
@@ -200,7 +200,7 @@ class Mock {
 
   testMock(mockedFunctions, mockName) {
     // LOOPING THROUGH FUNCTIONS IN THE MOCKS
-    _.forEach(mockedFunctions, function (mockedFunction, funcName) {
+    _.forEach(mockedFunctions, (mockedFunction, funcName) => {
       let actualResults = mockedFunction.actual,
         expectedResults = mockedFunction.expected,
         expectedResultsFromShouldAlways = mockedFunction.expectedAlways;
@@ -211,13 +211,13 @@ class Mock {
       }
 
       // LOOPING THROUGH ACTUAL RESULTS BY FUNCTION
-      _.forEach(actualResults, function (actualResult, actualResultIndex) {
+      _.forEach(actualResults, (actualResult, actualResultIndex) => {
         let countOrdinalValue = ordinalValues[actualResultIndex] || actualResultIndex,
           expectedResult = expectedResultsFromShouldAlways || expectedResults[actualResultIndex],
           numActualParams = 0, numExpectedParams = 0;
 
         // LOOPING THROUGH PARAMETERS OF A SINGLE ACTUAL RESULT
-        _.forEach(actualResult, function (actualParamResult, actualParamResultIndex) {
+        _.forEach(actualResult, (actualParamResult, actualParamResultIndex) => {
           if (actualParamResult) {
             numActualParams++;
           }
@@ -236,7 +236,7 @@ class Mock {
           let message = ErrorFactory.build(constants.errorMessages.ComparisonShouldEqual, [paramOrdinalValue, mockName, funcName, countOrdinalValue]);
 
           this.compare(actualParamResult, expectedParamResult, usingShouldAlways, message);
-        }.bind(this));
+        });
 
         _.forEach(expectedResult, function (expectedParamResult) {
           if (expectedParamResult) {
@@ -246,8 +246,8 @@ class Mock {
 
         preconditions.checkArgument(numActualParams === numExpectedParams, ErrorFactory.build(constants.errorMessages.WrongNumberOfParams, [countOrdinalValue, mockName, funcName, numExpectedParams, numActualParams]));
 
-      }.bind(this));
-    }.bind(this));
+      });
+    });
   }
 
   compare(actual, expected, usingShouldAlways, message) {

--- a/lib/scenarios/functional/from-callback-scenario.js
+++ b/lib/scenarios/functional/from-callback-scenario.js
@@ -11,7 +11,7 @@ class FromCallbackScenario extends Scenario {
   test(testableFunction) {
     this.validate(testableFunction);
 
-    this._inputParams_.push(function (err, result) {
+    this._inputParams_.push((err, result) => {
       if (err) {
         this._restoreMocks_();
         testableFunction(err);
@@ -29,7 +29,7 @@ class FromCallbackScenario extends Scenario {
           Errr.newError(ErrorFactory.build(constants.errorMessages.CatchOwnErrors)).appendTo(testError).throw();
         }
       }
-    }.bind(this));
+    });
 
     this._entryPointFunction_.apply(this._entryPointObject_, this._inputParams_);
   }

--- a/lib/scenarios/functional/from-promise-scenario.js
+++ b/lib/scenarios/functional/from-promise-scenario.js
@@ -12,7 +12,7 @@ class FromPromiseScenario extends Scenario {
     this.validate(testableFunction);
 
     this.calledTestableFunction = false;
-    this._entryPointFunction_.apply(this._entryPointObject_, this._inputParams_).then(function (result) {
+    this._entryPointFunction_.apply(this._entryPointObject_, this._inputParams_).then((result) => {
       this._mock_.test();
 
       this.calledTestableFunction = true;
@@ -20,7 +20,7 @@ class FromPromiseScenario extends Scenario {
 
       this._restoreMocks_();
 
-    }.bind(this)).catch(function (err) {
+    }).catch((err) => {
       try {
         this._restoreMocks_();
 
@@ -32,7 +32,7 @@ class FromPromiseScenario extends Scenario {
       } catch (mockTestError) {
         testableFunction(mockTestError, undefined);
       }
-    }.bind(this));
+    });
   }
 }
 

--- a/lib/scenarios/functional/http-req-scenario.js
+++ b/lib/scenarios/functional/http-req-scenario.js
@@ -59,28 +59,28 @@ class HttpReqScenario extends Scenario {
     preconditions.checkArgument(this._finishedHasBeenSet_, ErrorFactory.build(constants.errorMessages.ExactlyOneResponseFinisher))
       .debug({responseFinishers: _.keys(constants.ResponseEndFunctions)}).test();
 
-    this._executeFunctionalTest_().then(function () {
+    this._executeFunctionalTest_().then(() => {
       this._resetScenario_();
       return this._executePerfTest_();
 
-    }.bind(this)).then(function () {
+    }).then(() => {
       this._restoreMocks_();
       done();
 
-    }.bind(this)).catch(function (err) {
+    }).catch((err) => {
       this._restoreMocks_();
       done(err);
 
-    }.bind(this));
+    });
   }
 
   _executeFunctionalTest_() {
-    return new Promise(function (resolve, reject) {
+    return new Promise((resolve, reject) => {
       if (this._shouldExecuteFunctionalTest_()) {
-        this._executeTest_().then(function () {
+        this._executeTest_().then(() => {
           this._mock_.test();
           resolve();
-        }.bind(this)).catch(function (err) {
+        }).catch(function (err) {
 
           reject(err);
         });
@@ -88,38 +88,38 @@ class HttpReqScenario extends Scenario {
       } else {
         resolve();
       }
-    }.bind(this));
+    });
   }
 
   _executePerfTest_() {
-    return new Promise(function (resolve) {
+    return new Promise((resolve) => {
       if (this._shouldExecutePerformanceTest_()) {
         let suite = new Benchmark.Suite();
 
         suite.add(this._perfTitle_, {
           defer: true,
-          fn: function (deferred) {
+          fn: (deferred) => {
 
-            this._mock_.setCallbackForResponseEnd(function () {
+            this._mock_.setCallbackForResponseEnd(() => {
               this._resetScenario_();
               deferred.resolve();
-            }.bind(this));
+            });
 
             this._entryPointFunction_.apply(this._entryPointObject_, this._inputParams_);
-          }.bind(this)
+          }
 
-        }).on("complete", function (result) {
+        }).on("complete", (result) => {
           let report = BenchWriterProxy.getReport();
 
           HttpReqScenario._addBenchResult_(this._perfTitle_, report, result);
           BenchWriterProxy.saveReport(report);
 
           resolve();
-        }.bind(this)).run();
+        }).run();
       } else {
         resolve();
       }
-    }.bind(this));
+    });
   }
 
   _executeTest_() {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "maddox": "./bin/maddox.js"
   },
   "engines": {
-    "node": ">=5.0.0"
+    "node": ">=6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change usage of function expressions with `bind(this)` calls to arrow functions which have lexical _this_ binding. Inside arrow functions the `arguments` object is not defined and the usage of rest parameters (which are only available on node v6) is enforced.

The update to node v6 comes for free since tests are not breaking and is always recommended sticking with an LTS version.
