### PR TITLE
[Mock]- Should test inputs in state that they were given

### DIFF
--- a/lib/mocks/mock.js
+++ b/lib/mocks/mock.js
@@ -143,10 +143,12 @@ class Mock {
     }
 
     sinon.stub(objectToMock, funcName, function () {
+      const argsArr = Array.prototype.slice.call(arguments); // need to do this otherwise clone deep does not carry over the length property of the arguments object
+      const args = _.cloneDeep(argsArr); // clones the arguments so that the mock will have them in the state when they were called regardless if they get modified by the code later on.
       let mockedResult,
         mock = this._mocks_[mockName][funcName];
 
-      mock.actual.push(arguments);
+      mock.actual.push(args);
 
       if (mock.responseEnd) {
         this.resolveForResponseEnd();
@@ -160,7 +162,7 @@ class Mock {
         mock.callCount = mock.callCount + 1;
 
         // This execution will call one of these three functions synchronousResult, callbackResult, or promiseResult.
-        mockedResult = this[mockedData.dataReturnType](mockName, funcName, mockedData, arguments);
+        mockedResult = this[mockedData.dataReturnType](mockName, funcName, mockedData, args);
       }
 
       return mockedResult;

--- a/spec/unit/scenario-proxies-unit-test.js
+++ b/spec/unit/scenario-proxies-unit-test.js
@@ -98,6 +98,50 @@ describe("When using a Scenario", function () {
         .test(done);
     });
 
+    it("it should test the mock inputParams with the state that they were called in", function (done) {
+      const newInputParams = [];
+      const newExpectedResponse = {foo: "b"};
+      const newTestContext = {};
+      const newTestMock = {};
+      const newTestMockParams = [{foo: "a"}];
+      const newTestMockResponse = [{foo: "a"}];
+
+      newTestMock.newTestFunction = function (input, callback) {
+        return callback(input);
+      };
+      newTestContext.entryPointObject = {};
+      newTestContext.entryPointObject.entryPointFunction = function (callback) {
+        const dynamicInput = {foo: "a"};
+
+        newTestMock.newTestFunction(dynamicInput, function (input) {
+          return input;
+        });
+        dynamicInput.foo = "b";
+        return callback(undefined, dynamicInput);
+      };
+
+      const NewScenario = Maddox.functional.FromCallbackScenario;
+
+      new NewScenario()
+        .mockThisFunction("newTestMock", "newTestFunction", newTestMock)
+
+        .withEntryPoint(newTestContext.entryPointObject, "entryPointFunction")
+        .withInputParams(newInputParams)
+
+        .shouldBeCalledWith("newTestMock", "newTestFunction", newTestMockParams)
+        .doesReturnWithCallback("newTestMock", "newTestFunction", newTestMockResponse)
+
+        .test(function (err, response) {
+          try {
+            Maddox.compare.shouldEqual({actual: err, expected: undefined});
+            Maddox.compare.shouldEqual({actual: response, expected: newExpectedResponse});
+            done();
+          } catch (testError) {
+            done(testError);
+          }
+        });
+    });
+
   });
 
   describe("and using a stateful factory proxy", function () {


### PR DESCRIPTION
Change Mock.js to clone incoming arguments so they keep original state.
Also added a test for it in scenario-proxies-unit-test.js
