### PR TITLE
Chore: Update dependencies to fix vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "deep-diff": "^1.0.2",
     "deep-object-diff": "^1.1.0",
     "errr": "2.x",
-    "eslint": "^8.9.0",
     "fs-extra": "5.x",
     "is-subset": "0.x",
     "lodash.clonedeep": "^4.5.0",
@@ -72,6 +71,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "4.x",
     "chance": "1.x",
+    "eslint": "^8.9.0",
     "semver": "5.x",
     "uuid": "1.x"
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fs-extra": "5.x",
     "is-subset": "0.x",
     "lodash.clonedeep": "^4.5.0",
-    "mocha": "7.x",
+    "mocha": "^9.2.1",
     "preconditions": "3.x",
     "simple-statistics": "5.x",
     "sinon": "4.x",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "deep-diff": "^1.0.2",
     "deep-object-diff": "^1.1.0",
     "errr": "2.x",
+    "eslint": "^8.9.0",
     "fs-extra": "5.x",
     "is-subset": "0.x",
     "lodash.clonedeep": "^4.5.0",
@@ -71,7 +72,6 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "4.x",
     "chance": "1.x",
-    "eslint": "6.x",
     "semver": "5.x",
     "uuid": "1.x"
   }


### PR DESCRIPTION
In `master` branch of this repo, `npm audit` shows:

`found 11 moderate severity vulnerabilities in 324 scanned packages`

these can all be traced to eslint and mocha subdependencies (specifically, the package `ansi-regex`).

example:
<img width="836" alt="Screen Shot 2022-02-19 at 5 11 56 PM" src="https://user-images.githubusercontent.com/15212985/154820798-51eb6af7-d3e8-45df-becb-3d24e0286a75.png">


In this PR, I update mocha and eslint to the earliest version that has the vulnerabilities fixed.

If you run `npm audit` on the current branch, you should see:
<img width="956" alt="Screen Shot 2022-02-19 at 5 12 55 PM" src="https://user-images.githubusercontent.com/15212985/154820814-667fac69-2e81-48c8-9780-c07195971d3b.png">

You can also observe that `npm run ut` and `npm run lint` have the same behavior on this branch and `master`, so it doesn't look like the upgrades broke aything.